### PR TITLE
Fix #22:  PetriNetIOImpl creates messages for [un]marshalling errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,22 +192,22 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.1</version>
                 <configuration>
-                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo-fix</altDeploymentRepository>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>
-                <version>0.9</version>
+                <version>0.11</version>
                 <configuration>
                     <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
                     <noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
-                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
-                    <branch>refs/heads/mvn-repo</branch>
+                    <outputDirectory>${project.build.directory}/mvn-repo-fix</outputDirectory>
+                    <branch>refs/heads/mvn-repo-fix</branch>
                     <includes><include>**/*</include></includes>
                     <repositoryName>PIPECore</repositoryName>
-                    <repositoryOwner>sarahtattersall</repositoryOwner>
+                    <repositoryOwner>sjdayday</repositoryOwner>   <!-- was sarahtattersall -->
                     <merge>true</merge>
                 </configuration>
                 <executions>

--- a/src/main/java/uk/ac/imperial/pipe/io/PetriNetIOImpl.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/PetriNetIOImpl.java
@@ -1,25 +1,38 @@
 package uk.ac.imperial.pipe.io;
 
-import uk.ac.imperial.pipe.io.adapters.modelAdapter.*;
-import uk.ac.imperial.pipe.models.PetriNetHolder;
-import uk.ac.imperial.pipe.models.petrinet.*;
+import java.awt.Color;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import java.awt.Color;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.Writer;
-import java.util.HashMap;
-import java.util.Map;
+
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.ArcAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.PlaceAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.RateParameterAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.TokenAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.TokenSetIntegerAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.TransitionAdapter;
+import uk.ac.imperial.pipe.models.PetriNetHolder;
+import uk.ac.imperial.pipe.models.petrinet.ColoredToken;
+import uk.ac.imperial.pipe.models.petrinet.FunctionalRateParameter;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+import uk.ac.imperial.pipe.models.petrinet.Place;
+import uk.ac.imperial.pipe.models.petrinet.Token;
+import uk.ac.imperial.pipe.models.petrinet.Transition;
 
 /**
  * Petri net IO implementation that writes and reads a Petri net using JAXB
  */
-public final class PetriNetIOImpl implements PetriNetIO {
+public class PetriNetIOImpl implements PetriNetIO {
 
     /**
      * JAXB context initialised in constructor
@@ -27,27 +40,61 @@ public final class PetriNetIOImpl implements PetriNetIO {
     private final JAXBContext context;
 
     /**
+     * PetriNetValidationEventHandler used to process validation events 
+     * Defaults to stopping processing in the event of a failure, but can be overridden to continue
+     * (should only continue when testing)
+     */
+    protected PetriNetValidationEventHandler petriNetValidationEventHandler;
+
+	private Unmarshaller unmarshaller;
+
+    /**
      * Constructor that sets the context to the {@link uk.ac.imperial.pipe.models.PetriNetHolder}
-     *
+     * Provides explicit control over validation processing:  
+     * continueProcessing flag enables processing to continue in the event of validation failure
+     * suppressUnexpectedElementMessages suppresses "unexpected element" messages from tags in the pnml
+     *   that are not explicitly supported by this version of PIPE. Behavior is modified depending on value of 
+     *   continueProcessing flag.  Only relevant during read operations
+     *   
+     * Cases: 
+     * continue=true, suppress=true:  processing continues, all messages suppressed (suitable only for testing)
+     * continue=true, suppress=false:  processing continues, all messages printed (suitable only for testing)
+     * continue=false, suppress=true:  processing stops at first message other than "unexpected element"; 
+     *     all "unexpected element" messages suppressed (default)
+     * continue=false, suppress=false:  processing stops at first message other than "unexpected element"; 
+     *     all messages printed
+     *  
+     * 
      * @throws JAXBException
      */
-    public PetriNetIOImpl() throws JAXBException {
-        context = JAXBContext.newInstance(PetriNetHolder.class);
+    public PetriNetIOImpl(boolean continueProcessing, boolean suppressUnexpectedElementMessages) throws JAXBException {
+    	context = JAXBContext.newInstance(PetriNetHolder.class);
+    	petriNetValidationEventHandler = new PetriNetValidationEventHandler(continueProcessing, suppressUnexpectedElementMessages); 
     }
 
     /**
+     * Constructor that sets the context to the {@link uk.ac.imperial.pipe.models.PetriNetHolder}
+     * Default settings of the continueProcessing and suppressUnexpectedElementMessage flags:
+     * processing stops at first message other than "unexpected element"; all "unexpected element" messages suppressed
+     * 
+     * @throws JAXBException
+     */
+    public PetriNetIOImpl() throws JAXBException {
+    	this(false, true); 
+    }
+
+    
+
+	/**
      * Writes the specified petri net to the given path
      *
      * @param path
      * @param petriNet
+	 * @throws IOException 
      */
     @Override
-    public void writeTo(String path, PetriNet petriNet) throws JAXBException {
-        Marshaller m = context.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-        PetriNetHolder holder = new PetriNetHolder();
-        holder.addNet(petriNet);
-        m.marshal(holder, new File(path));
+    public void writeTo(String path, PetriNet petriNet) throws JAXBException, IOException {
+		writeTo(new FileWriter(new File(path)), petriNet);
     }
 
     /**
@@ -59,11 +106,22 @@ public final class PetriNetIOImpl implements PetriNetIO {
     @Override
     public void writeTo(Writer stream, PetriNet petriNet) throws JAXBException {
         Marshaller m = context.createMarshaller();
+        m.setEventHandler(getEventHandler()); 
         m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-        PetriNetHolder holder = new PetriNetHolder();
+        PetriNetHolder holder = getPetriNetHolder();
         holder.addNet(petriNet);
-        m.marshal(holder, stream);
+        try {
+        	m.marshal(holder, stream);
+        	getEventHandler().printMessages(); 
+		} catch (JAXBException e) {
+			getEventHandler().printMessages(); 
+			throw e; 
+		}
     }
+
+	protected PetriNetHolder getPetriNetHolder() {
+		return new PetriNetHolder();
+	}
 
     /**
      * Reads a Petri net from the given path
@@ -73,8 +131,16 @@ public final class PetriNetIOImpl implements PetriNetIO {
      */
     @Override
     public PetriNet read(String path) throws JAXBException, FileNotFoundException {
-        Unmarshaller um = initialiseUnmarshaller();
-        PetriNetHolder holder = (PetriNetHolder) um.unmarshal(new FileReader(path));
+        initialiseUnmarshaller();
+        getUnmarshaller().setEventHandler(getEventHandler()); 
+        PetriNetHolder holder = null; 
+        try {
+        	holder = (PetriNetHolder) getUnmarshaller().unmarshal(new FileReader(path));
+        	getEventHandler().printMessages(); 
+		} catch (JAXBException e) {
+			getEventHandler().printMessages(); 
+			throw e;  
+		} 
         PetriNet petriNet = holder.getNet(0);
         if (petriNet.getTokens().isEmpty()) {
             Token token = createDefaultToken();
@@ -84,26 +150,28 @@ public final class PetriNetIOImpl implements PetriNetIO {
     }
 
     /**
-     * @return initialised unmarshaller with the correct adapters needed
+     * initialize unmarshaller with the correct adapters needed
      * @throws JAXBException
      */
-    private Unmarshaller initialiseUnmarshaller() throws JAXBException {
+    protected void initialiseUnmarshaller() throws JAXBException {
 
-        Unmarshaller um = context.createUnmarshaller();
-
+        unmarshaller = context.createUnmarshaller();
         Map<String, Place> places = new HashMap<>();
         Map<String, Transition> transitions = new HashMap<>();
         Map<String, Token> tokens = new HashMap<>();
         Map<String, FunctionalRateParameter> rateParameters = new HashMap<>();
 
-        um.setAdapter(new RateParameterAdapter(rateParameters));
-        um.setAdapter(new ArcAdapter(places, transitions));
-        um.setAdapter(new PlaceAdapter(places));
-        um.setAdapter(new TransitionAdapter(transitions, rateParameters));
-        um.setAdapter(new TokenAdapter(tokens));
-        um.setAdapter(new TokenSetIntegerAdapter(tokens));
-        return um;
+        unmarshaller.setAdapter(new RateParameterAdapter(rateParameters));
+        unmarshaller.setAdapter(new ArcAdapter(places, transitions));
+        unmarshaller.setAdapter(new PlaceAdapter(places));
+        unmarshaller.setAdapter(new TransitionAdapter(transitions, rateParameters));
+        unmarshaller.setAdapter(new TokenAdapter(tokens));
+        unmarshaller.setAdapter(new TokenSetIntegerAdapter(tokens));
     }
+
+	protected PetriNetValidationEventHandler getEventHandler() {
+		return petriNetValidationEventHandler;
+	}
 
     /**
      * @return a new default token
@@ -111,5 +179,9 @@ public final class PetriNetIOImpl implements PetriNetIO {
     private Token createDefaultToken() {
         return new ColoredToken("Default", new Color(0, 0, 0));
     }
+
+	protected final Unmarshaller getUnmarshaller() {
+		return unmarshaller;
+	}
 
 }

--- a/src/main/java/uk/ac/imperial/pipe/io/PetriNetValidationEventHandler.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/PetriNetValidationEventHandler.java
@@ -1,0 +1,110 @@
+package uk.ac.imperial.pipe.io;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.ValidationEventHandler;
+import javax.xml.bind.ValidationEventLocator;
+
+
+public class PetriNetValidationEventHandler implements ValidationEventHandler {
+
+	private boolean continueProcessing;
+	private ValidationEvent event;
+	private List<FormattedEvent> formattedEvents;
+	private boolean suppressUnexpectedElementMessages;
+
+	public PetriNetValidationEventHandler() {
+		this(false, true); 
+	}
+	
+	public PetriNetValidationEventHandler(boolean continueProcessing, boolean suppressUnexpectedElementMessages) {
+		this.continueProcessing = continueProcessing; 
+		this.suppressUnexpectedElementMessages = suppressUnexpectedElementMessages; 
+		formattedEvents = new ArrayList<>();  
+	}
+
+//    * Cases: 
+//    * continue=true, suppress=true:  processing continues, all messages suppressed (suitable only for testing)
+//    * continue=true, suppress=false:  processing continues, all messages printed (suitable only for testing)
+//    * continue=false, suppress=true:  processing stops at first message other than "unexpected element"; 
+//    *     all "unexpected element" messages suppressed (default)
+//    * continue=false, suppress=false:  processing stops at first message other than "unexpected element"; 
+//    *     all messages printed
+
+	
+	@Override
+	public boolean handleEvent(ValidationEvent event) {
+		this.event = event;
+		boolean unexpectedElement = saveAndCheckUnexpectedElement(event);
+		if ((unexpectedElement) && (!continueProcessing)) {
+			return true;  // continue only if saw unexpected element 
+		}
+		else return continueProcessing;
+	}
+
+	public void printMessages() {
+		for (FormattedEvent event : formattedEvents) {
+			if (printMessage(event)) {
+				System.err.println(event.formattedEvent); 
+			}
+		}
+	}
+
+	protected boolean printMessage(FormattedEvent event) {
+		if (!suppressUnexpectedElementMessages) {
+			return true;
+		}
+		else if ((!continueProcessing) && (!event.unexpected)) {
+			return true;
+		}
+		else return false; 
+	}
+
+	private boolean saveAndCheckUnexpectedElement(ValidationEvent event) {
+		if ((event.getLinkedException() == null) && (event.getMessage().startsWith("unexpected element"))) {
+			formattedEvents.add(new FormattedEvent(true, printEvent())); 
+			return true;
+		}
+		else {
+			formattedEvents.add(new FormattedEvent(false, printEvent())); 
+			return false;
+		}
+	}
+
+	public String printEvent() {
+		ValidationEventLocator locator = event.getLocator(); 
+		StringBuffer sb = new StringBuffer(); 
+		sb.append("PetriNetValidationEventHandler received a ValidationEvent, probably during processing by PetriNetIOImpl.  Details: "); 
+		sb.append("\nMessage: "); 
+		sb.append(event.getMessage()); 
+		sb.append("\nObject: "); 
+		sb.append((locator.getObject() != null) ? (locator.getObject().toString()) : "null"); 
+		sb.append("\nURL: "); 
+		sb.append((locator.getURL() != null) ? (locator.getURL().toString()) : "null"); 
+		sb.append("\nNode: "); 
+		sb.append((locator.getNode() != null) ? (locator.getNode().toString()) : "null"); 
+		sb.append("\nLine: "); 
+		sb.append(locator.getLineNumber()); 
+		sb.append("\nColumn: "); 
+		sb.append(locator.getColumnNumber()); 
+		sb.append("\nLinked exception: "); 
+		sb.append((event.getLinkedException() != null) ? (event.getLinkedException().getMessage()) : "null"); 
+		return sb.toString();
+	}
+
+	public List<FormattedEvent> getFormattedEvents() {
+		return formattedEvents;
+	}
+	protected class FormattedEvent {
+		public boolean unexpected; 
+		public String formattedEvent; 
+		
+		public FormattedEvent(boolean unexpected, String formattedEvent) {
+			this.unexpected = unexpected; 
+			this.formattedEvent = formattedEvent; 
+		}
+		
+	}
+}

--- a/src/main/java/uk/ac/imperial/pipe/io/PetriNetWriter.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/PetriNetWriter.java
@@ -3,6 +3,8 @@ package uk.ac.imperial.pipe.io;
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 
 import javax.xml.bind.JAXBException;
+
+import java.io.IOException;
 import java.io.Writer;
 
 /**
@@ -14,8 +16,9 @@ public interface PetriNetWriter {
      * Write the petri net to the given path
      * @param path
      * @param petriNet
+     * @throws IOException 
      */
-    void writeTo(String path, PetriNet petriNet) throws JAXBException;
+    void writeTo(String path, PetriNet petriNet) throws JAXBException, IOException;
 
     /**
      * Write the Petri net to the given stream

--- a/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/PetriNetAdapter.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/PetriNetAdapter.java
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 /**
  * Marshals a Petri net into the verbose format needed for PNML
  */
-public final class PetriNetAdapter extends XmlAdapter<AdaptedPetriNet, PetriNet> {
+public class PetriNetAdapter extends XmlAdapter<AdaptedPetriNet, PetriNet> {
     /**
      *
      * @param v

--- a/src/main/java/uk/ac/imperial/pipe/models/manager/PetriNetManager.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/manager/PetriNetManager.java
@@ -7,6 +7,7 @@ import javax.xml.bind.JAXBException;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  * Responsible for creating and managing Petri nets
@@ -52,9 +53,10 @@ public interface PetriNetManager {
      *
      * @param petriNet petri net to save
      * @param outFile file to save petri net to
+     * @throws IOException 
      */
     //TODO: SHOULD REALLY TELL IT TO SAVE ONE OF ITS OWN PETRI NETS RATHER THAN PASSING IT IN
-    void savePetriNet(PetriNet petriNet, File outFile) throws JAXBException;
+    void savePetriNet(PetriNet petriNet, File outFile) throws JAXBException, IOException;
 
     /**
      * Remove this Petri net from storage

--- a/src/main/java/uk/ac/imperial/pipe/models/manager/PetriNetManagerImpl.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/manager/PetriNetManagerImpl.java
@@ -18,6 +18,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  * Manages addition and deletion of Petri nets. It uses the publish-subscribe design
@@ -102,9 +103,10 @@ public final class PetriNetManagerImpl implements PetriNetManager {
      * @param petriNet petri net to save
      * @param outFile file to save petri net to
      * @throws JAXBException
+     * @throws IOException 
      */
     @Override
-    public void savePetriNet(PetriNet petriNet, File outFile) throws JAXBException {
+    public void savePetriNet(PetriNet petriNet, File outFile) throws JAXBException, IOException {
 
         uk.ac.imperial.pipe.io.PetriNetWriter writer = new PetriNetIOImpl();
         writer.writeTo(outFile.getAbsolutePath(), petriNet);

--- a/src/test/java/uk/ac/imperial/pipe/io/PetriNetReaderTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/PetriNetReaderTest.java
@@ -1,35 +1,68 @@
 package uk.ac.imperial.pipe.io;
 
-import org.junit.Before;
-import org.junit.Test;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
-import uk.ac.imperial.pipe.models.petrinet.*;
-import utils.FileUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.extractProperty;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import javax.xml.bind.JAXBException;
 import java.awt.Color;
 import java.awt.geom.Point2D;
 import java.io.FileNotFoundException;
 import java.util.Collection;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.UnmarshalException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.PetriNetAdapter;
+import uk.ac.imperial.pipe.io.adapters.modelAdapter.TestingThrowsPetriNetAdapter;
+import uk.ac.imperial.pipe.models.petrinet.Arc;
+import uk.ac.imperial.pipe.models.petrinet.ArcPoint;
+import uk.ac.imperial.pipe.models.petrinet.ArcType;
+import uk.ac.imperial.pipe.models.petrinet.ColoredToken;
+import uk.ac.imperial.pipe.models.petrinet.Connectable;
+import uk.ac.imperial.pipe.models.petrinet.DiscretePlace;
+import uk.ac.imperial.pipe.models.petrinet.DiscreteTransition;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+import uk.ac.imperial.pipe.models.petrinet.Place;
+import uk.ac.imperial.pipe.models.petrinet.RateParameter;
+import uk.ac.imperial.pipe.models.petrinet.Token;
+import uk.ac.imperial.pipe.models.petrinet.Transition;
+import utils.FileUtils;
 
 public class PetriNetReaderTest {
 
+ 	
     private static final String DEFAULT_TOKEN = "Default";
     private static final String RED_TOKEN = "Red";
     PetriNetReader reader;
 
     @Before
     public void setUp() throws JAXBException {
-        reader = new PetriNetIOImpl();
+        reader = new PetriNetIOImpl();  // Defaults to false,true
+//        reader = new PetriNetIOImpl(false, true);  
+    }
+
+//    @Test
+    public void readNetForDebugging() throws  JAXBException, FileNotFoundException {
+    	PetriNet petriNet = null; 
+    	petriNet = reader.read("/Users/stevedoubleday/dissertation/navigation/heteroassociation1.xml");
+
+//        petriNet = reader.read("/some/path/somepnml.xml");
+        assertNotNull(petriNet); 
     }
 
     @Test
     public void createGSPN() throws  JAXBException, FileNotFoundException {
+    	//XML has unparsed tags 
+        reader = new PetriNetIOImpl(true, true);  // change to true, false to see error
         PetriNet petriNet = reader.read(FileUtils.fileLocation("/xml/gspn1.xml"));
         assertEquals(5, petriNet.getPlaces().size());
         assertEquals(5, petriNet.getTransitions().size());
@@ -99,7 +132,6 @@ public class PetriNetReaderTest {
 
     @Test
     public void createsMarkingIfNoTokensSet() throws JAXBException, FileNotFoundException {
-
         PetriNet petriNet = reader.read(FileUtils.fileLocation(getNoPlaceTokenPath()));
         assertThat(petriNet.getPlaces()).isNotEmpty();
         Place place = petriNet.getPlaces().iterator().next();
@@ -160,6 +192,8 @@ public class PetriNetReaderTest {
 
     @Test
     public void createsInhibitoryArc() throws JAXBException, FileNotFoundException {
+    	//XML has unparsed tags 
+        reader = new PetriNetIOImpl(true, true);  // change to true, false to see error
         PetriNet petriNet = reader.read(FileUtils.fileLocation(XMLUtils.getInhibitorArcFile()));
         assertThat(petriNet.getArcs()).extracting("type").containsExactly(ArcType.INHIBITOR);
     }
@@ -194,13 +228,113 @@ public class PetriNetReaderTest {
         assertEquals(rateParameter, transition.getRate());
     }
 
-
     @Test
     public void readsTokens() throws PetriNetComponentNotFoundException, JAXBException, FileNotFoundException {
-        PetriNet petriNet = reader.read(FileUtils.fileLocation("/xml/token/two_token.xml"));
+        PetriNet petriNet = reader.read(FileUtils.fileLocation(XMLUtils.getTwoTokenFile()));
         Collection<Token> tokens = petriNet.getTokens();
         assertEquals(2,tokens.size());
     }
+    @Test
+    public void messagePrintedWithoutThrowingWhenUnexpectedElement() throws PetriNetComponentNotFoundException, JAXBException, FileNotFoundException {
+        reader = new TestingPetriNetIOImpl(true, false); 
+        checkPrintedAndDoesntThrowWhenUnexpectedElement();
+    }
+    @Test
+    public void messagePrintedButDoesntThrowWhenUnexpectedElement() throws PetriNetComponentNotFoundException, JAXBException, FileNotFoundException {
+    	reader = new TestingPetriNetIOImpl(false, false); 
+    	checkPrintedAndDoesntThrowWhenUnexpectedElement();
+    }
 
+	protected void checkPrintedAndDoesntThrowWhenUnexpectedElement()
+			throws JAXBException, FileNotFoundException {
+		@SuppressWarnings("unused")
+		PetriNet petriNet = reader.read(FileUtils.fileLocation(XMLUtils.getInvalidPetriNetFile()));
+        PetriNetValidationEventHandler handler = ((PetriNetIOImpl) reader).getEventHandler();  
+    	assertEquals("PetriNetValidationEventHandler received a ValidationEvent, probably during processing by PetriNetIOImpl.  Details: \n" +
+    			"Message: unexpected element (uri:\"\", local:\"blah\"). Expected elements are <{}definition>,<{}arc>,<{}token>,<{}labels>,<{}transition>,<{}place>\n" +
+    			"Object: null\n" +
+    			"URL: null\n" +
+    			"Node: null\n" +
+    			"Line: 4\n" +
+    			"Column: 16\n" +
+    			"Linked exception: null", handler.getFormattedEvents().get(0).formattedEvent);
+    	assertTrue(handler.printMessage(handler.getFormattedEvents().get(0)));
+	}
+    @Test
+    public void noMessagePrintedAndDoesntThrowWhenUnexpectedElement() throws PetriNetComponentNotFoundException, JAXBException, FileNotFoundException {
+    	reader = new PetriNetIOImpl(true, true);   
+    	@SuppressWarnings("unused")
+    	PetriNet petriNet = reader.read(FileUtils.fileLocation(XMLUtils.getInvalidPetriNetFile()));
+    	PetriNetValidationEventHandler handler = ((PetriNetIOImpl) reader).getEventHandler();  
+    	assertEquals(true, handler.getFormattedEvents().get(0).unexpected); 
+    	assertFalse(handler.printMessage(handler.getFormattedEvents().get(0)));
+    }
+    @Test
+    public void messagePrintedAndThrowsForFirstNonUnexpectedElementError() throws PetriNetComponentNotFoundException, JAXBException, FileNotFoundException {
+    	reader = new TestingThrowsPetriNetIOImpl(false, true);  // true false 
+    	try {
+    		@SuppressWarnings("unused")
+    		PetriNet petriNet = reader.read(FileUtils.fileLocation(XMLUtils.getInvalidPetriNetFile()));
+    	} catch (UnmarshalException e) {
+    		assertEquals("java.lang.RuntimeException: TestingThrowsPetriNetAdapter exception.", e.getMessage()); 
+    	}
+    	PetriNetValidationEventHandler handler = ((PetriNetIOImpl) reader).getEventHandler();  
+    	assertEquals(2, handler.getFormattedEvents().size());
+    	assertEquals("PetriNetValidationEventHandler received a ValidationEvent, probably during processing by PetriNetIOImpl.  Details: \n" +
+    			"Message: unexpected element (uri:\"\", local:\"blah\"). Expected elements are <{}definition>,<{}arc>,<{}token>,<{}labels>,<{}transition>,<{}place>\n" +
+    			"Object: null\n" +
+    			"URL: null\n" +
+    			"Node: null\n" +
+    			"Line: 4\n" +
+    			"Column: 16\n" +
+    			"Linked exception: null", handler.getFormattedEvents().get(0).formattedEvent);
+    	assertEquals(true, handler.getFormattedEvents().get(0).unexpected); 
+    	assertFalse(handler.printMessage(handler.getFormattedEvents().get(0)));
+    	assertEquals("PetriNetValidationEventHandler received a ValidationEvent, probably during processing by PetriNetIOImpl.  Details: \n" +
+    			"Message: java.lang.RuntimeException: TestingThrowsPetriNetAdapter exception.\n" +
+    			"Object: null\n" +
+    			"URL: null\n" +
+    			"Node: null\n" +
+    			"Line: 26\n" +
+    			"Column: 11\n" +
+    			"Linked exception: java.lang.RuntimeException: TestingThrowsPetriNetAdapter exception.", handler.getFormattedEvents().get(1).formattedEvent);
+    	assertEquals(false, handler.getFormattedEvents().get(1).unexpected); 
+    	assertTrue(handler.printMessage(handler.getFormattedEvents().get(1)));
+    }
+    private class TestingPetriNetIOImpl extends PetriNetIOImpl {
 
+		public TestingPetriNetIOImpl(boolean continueProcessing,
+				boolean suppressUnexpectedElementMessages) throws JAXBException {
+			super(continueProcessing, suppressUnexpectedElementMessages);
+	    	petriNetValidationEventHandler = new TestingPetriNetValidationEventHandler(continueProcessing, suppressUnexpectedElementMessages); 
+		}
+		@Override
+		protected void initialiseUnmarshaller() throws JAXBException {
+			super.initialiseUnmarshaller();
+		}
+    }
+    private class TestingThrowsPetriNetIOImpl extends TestingPetriNetIOImpl {
+    	
+    	public TestingThrowsPetriNetIOImpl(boolean continueProcessing,
+    			boolean suppressUnexpectedElementMessages) throws JAXBException {
+    		super(continueProcessing, suppressUnexpectedElementMessages);
+    		petriNetValidationEventHandler = new TestingPetriNetValidationEventHandler(continueProcessing, suppressUnexpectedElementMessages); 
+    	}
+    	@Override
+    	protected void initialiseUnmarshaller() throws JAXBException {
+    		super.initialiseUnmarshaller();
+    		getUnmarshaller().setAdapter(PetriNetAdapter.class, new TestingThrowsPetriNetAdapter()); 
+    	}
+    }
+    private class TestingPetriNetValidationEventHandler extends PetriNetValidationEventHandler {
+
+		public TestingPetriNetValidationEventHandler(
+				boolean continueProcessing,
+				boolean suppressUnexpectedElementMessages) {
+			super(continueProcessing, suppressUnexpectedElementMessages);
+		}
+    	@Override
+    	public void printMessages() {
+    	}
+    }
 }

--- a/src/test/java/uk/ac/imperial/pipe/io/PetriNetWriterTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/PetriNetWriterTest.java
@@ -1,20 +1,35 @@
 package uk.ac.imperial.pipe.io;
 
-import org.custommonkey.xmlunit.XMLTestCase;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.xml.sax.SAXException;
-import uk.ac.imperial.pipe.dsl.*;
-import uk.ac.imperial.pipe.exceptions.InvalidRateException;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
-import uk.ac.imperial.pipe.models.petrinet.*;
-import uk.ac.imperial.pipe.models.petrinet.AnnotationImpl;
-import utils.FileUtils;
-
-import javax.xml.bind.JAXBException;
 import java.awt.Color;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import java.util.Collection;
+
+import javax.xml.bind.JAXBException;
+
+import org.custommonkey.xmlunit.XMLTestCase;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.xml.sax.SAXException;
+
+import uk.ac.imperial.pipe.dsl.ANormalArc;
+import uk.ac.imperial.pipe.dsl.APetriNet;
+import uk.ac.imperial.pipe.dsl.APlace;
+import uk.ac.imperial.pipe.dsl.AToken;
+import uk.ac.imperial.pipe.dsl.AnImmediateTransition;
+import uk.ac.imperial.pipe.exceptions.InvalidRateException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
+import uk.ac.imperial.pipe.models.petrinet.AnnotationImpl;
+import uk.ac.imperial.pipe.models.petrinet.ColoredToken;
+import uk.ac.imperial.pipe.models.petrinet.DiscretePlace;
+import uk.ac.imperial.pipe.models.petrinet.DiscreteTransition;
+import uk.ac.imperial.pipe.models.petrinet.FunctionalRateParameter;
+import uk.ac.imperial.pipe.models.petrinet.NormalRate;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+import uk.ac.imperial.pipe.models.petrinet.Place;
+import uk.ac.imperial.pipe.models.petrinet.Token;
+import uk.ac.imperial.pipe.models.petrinet.Transition;
+import utils.FileUtils;
 
 public class PetriNetWriterTest extends XMLTestCase {
     PetriNetWriter writer;
@@ -25,6 +40,16 @@ public class PetriNetWriterTest extends XMLTestCase {
         writer = new PetriNetIOImpl();
     }
 
+    public void testInvalidNetGeneratesUnderstandableMessage() throws Exception {
+    	writer = new PetriNetIOImpl(true, true);
+    	PetriNet petriNet = new InvalidPetriNet();
+    	StringWriter stringWriter = new StringWriter();
+    	writer.writeTo(stringWriter, petriNet);
+    	assertTrue(((PetriNetIOImpl) writer).getEventHandler().getFormattedEvents().get(0).formattedEvent.startsWith(
+    		"PetriNetValidationEventHandler received a ValidationEvent, probably during processing by PetriNetIOImpl.  Details: \n" +
+    	    "Message: TestingInvalidPetriNet threw an exception for testing"));
+    }
+    
     public void testMarshalsPlace() throws IOException, SAXException, JAXBException {
         PetriNet petriNet = new PetriNet();
         Token token = new ColoredToken("Red", new Color(255, 0, 0));
@@ -109,6 +134,12 @@ public class PetriNetWriterTest extends XMLTestCase {
         AnnotationImpl annotation = new AnnotationImpl(93, 145, "#P12s", 48, 20, false);
         petriNet.addAnnotation(annotation);
         assertResultsEqual(FileUtils.fileLocation(XMLUtils.getAnnotationFile()), petriNet);
+    }
+    private class InvalidPetriNet extends PetriNet {
+    	@Override
+    	public Collection<Token> getTokens() {
+    		throw new RuntimeException("TestingInvalidPetriNet threw an exception for testing.");
+    	}
     }
 }
 

--- a/src/test/java/uk/ac/imperial/pipe/io/XMLUtils.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/XMLUtils.java
@@ -56,10 +56,18 @@ public class XMLUtils {
         return "/xml/place/singlePlace.xml";
     }
 
+    public static String getInvalidPetriNetFile() {
+    	return "/xml/invalidPetriNet.xml";
+    }
+    public static String getTwoTokenFile() {
+    	return "/xml/token/two_token.xml";
+    }
     public static String readFile(String path, Charset encoding)
             throws IOException
     {
         byte[] encoded = Files.readAllBytes(Paths.get(path));
         return encoding.decode(ByteBuffer.wrap(encoded)).toString();
     }
+
+
 }

--- a/src/test/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/TestingThrowsPetriNetAdapter.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/TestingThrowsPetriNetAdapter.java
@@ -1,0 +1,15 @@
+package uk.ac.imperial.pipe.io.adapters.modelAdapter;
+
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
+import uk.ac.imperial.pipe.io.adapters.model.AdaptedPetriNet;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+
+public class TestingThrowsPetriNetAdapter extends PetriNetAdapter {
+	
+	@Override
+	public PetriNet unmarshal(AdaptedPetriNet v)
+			throws PetriNetComponentException {
+		throw new RuntimeException("TestingThrowsPetriNetAdapter exception."); 
+	}
+
+}

--- a/src/test/resources/xml/invalidPetriNet.xml
+++ b/src/test/resources/xml/invalidPetriNet.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<pnml>
+    <net id="invalid" type="fred">
+        <blah/>
+        <token id="Default" enabled="true" red="0" green="0" blue="0"/>
+        <place id="P0">
+            <graphics>
+                <position x="225.0" y="240.0"/>
+            </graphics>
+            <name>
+                <value>P0</value>
+                <graphics>
+                    <offset x="0.0" y="0.0"/>
+                </graphics>
+            </name>
+            <initialMarking>
+                <value>Default,1</value>
+                <graphics>
+                    <offset x="0.0" y="0.0"/>
+                </graphics>
+            </initialMarking>
+            <capacity>
+                <value>0</value>
+            </capacity>
+        </place>
+    </net>
+</pnml>


### PR DESCRIPTION
uk.ac.imperial.pipe.io.PetriNetIOImpl now throws exceptions for marshalling and unmarshalling errors.  Two flags in its constructor control whether processing continues after encountering an errors, and under what circumstances errors are reported.  

The current JAXB implementation expects a defined set of XML tags, but some pnml files may have additional tags.  Such files still work under the previous code, but under the new code, these will generate an "unexpected element" message.  To avoid failing to open these files, such messages will be suppressed by default; other errors will be reported.  