### PR TITLE
fix #24: rate parameters processed after places during xml read, clone,

### DIFF
--- a/src/main/java/uk/ac/imperial/pipe/dsl/APetriNet.java
+++ b/src/main/java/uk/ac/imperial/pipe/dsl/APetriNet.java
@@ -66,8 +66,9 @@ public final class APetriNet {
      * @param finalCreator last item creator to add to Petri net
      * @param <T> type of PetriNetComponent
      * @return the created Petri net containing all the items made from the added creators
+     * @throws PetriNetComponentException 
      */
-    public  <T extends PetriNetComponent> PetriNet andFinally(DSLCreator<T> finalCreator) {
+    public  <T extends PetriNetComponent> PetriNet andFinally(DSLCreator<T> finalCreator) throws PetriNetComponentException {
         return and(finalCreator).makePetriNet();
     }
 
@@ -76,8 +77,9 @@ public final class APetriNet {
      * @param creator item creator to add to Petri net
      * @param <T> type of PetriNetComponent
      * @return created petri net containing the item
+     * @throws PetriNetComponentException 
      */
-    public static <T extends PetriNetComponent> PetriNet withOnly(DSLCreator<T> creator) {
+    public static <T extends PetriNetComponent> PetriNet withOnly(DSLCreator<T> creator) throws PetriNetComponentException {
         APetriNet aPetriNet = new APetriNet();
         return aPetriNet.andFinally(creator);
     }
@@ -86,8 +88,9 @@ public final class APetriNet {
      * Creates a petri net by looping through the creators and calling
      * their create methods
      * @return petri net with components added
+     * @throws PetriNetComponentException 
      */
-    private PetriNet makePetriNet() {
+    private PetriNet makePetriNet() throws PetriNetComponentException {
         Map<String, Token> tokens = new HashMap<>();
         Map<String, Place> places = new HashMap<>();
         Map<String, Transition> transitions = new HashMap<>();
@@ -98,7 +101,7 @@ public final class APetriNet {
             try {
                 petriNet.add(creator.create(tokens, places, transitions, rateParameters));
             } catch (PetriNetComponentException e) {
-                LOGGER.log(Level.SEVERE, e.getMessage());
+                throw e; 
             }
         }
         return petriNet;

--- a/src/main/java/uk/ac/imperial/pipe/dsl/DSLCreator.java
+++ b/src/main/java/uk/ac/imperial/pipe/dsl/DSLCreator.java
@@ -34,8 +34,8 @@ public interface DSLCreator<T extends PetriNetComponent> {
      *
      * A suggested order would be
      * Tokens
-     * RateParameters
      * Places
+     * RateParameters
      * Transitions
      * Arcs
      *

--- a/src/main/java/uk/ac/imperial/pipe/exceptions/PetriNetComponentException.java
+++ b/src/main/java/uk/ac/imperial/pipe/exceptions/PetriNetComponentException.java
@@ -3,6 +3,7 @@ package uk.ac.imperial.pipe.exceptions;
 /**
  * Represents an error that can be thrown by the {@link uk.ac.imperial.pipe.models.petrinet.PetriNet}
  * when modifying the components it stores
+ * known subclasses:  {@link PetriNetComponentNotFoundException}
  */
 public class PetriNetComponentException  extends Exception {
     /**

--- a/src/main/java/uk/ac/imperial/pipe/exceptions/PetriNetComponentNotFoundException.java
+++ b/src/main/java/uk/ac/imperial/pipe/exceptions/PetriNetComponentNotFoundException.java
@@ -4,7 +4,7 @@ package uk.ac.imperial.pipe.exceptions;
  * Exception thrown from the {@link uk.ac.imperial.pipe.models.petrinet.PetriNet} when
  * searching for a component that does not exist
  */
-public class PetriNetComponentNotFoundException extends Exception {
+public class PetriNetComponentNotFoundException extends PetriNetComponentException {
     /**
      *
      * @param message message of the exception

--- a/src/main/java/uk/ac/imperial/pipe/io/PetriNetValidationEventHandler.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/PetriNetValidationEventHandler.java
@@ -15,24 +15,16 @@ public class PetriNetValidationEventHandler implements ValidationEventHandler {
 	private List<FormattedEvent> formattedEvents;
 	private boolean suppressUnexpectedElementMessages;
 
-	public PetriNetValidationEventHandler() {
-		this(false, true); 
-	}
-	
 	public PetriNetValidationEventHandler(boolean continueProcessing, boolean suppressUnexpectedElementMessages) {
 		this.continueProcessing = continueProcessing; 
 		this.suppressUnexpectedElementMessages = suppressUnexpectedElementMessages; 
 		formattedEvents = new ArrayList<>();  
 	}
 
-//    * Cases: 
-//    * continue=true, suppress=true:  processing continues, all messages suppressed (suitable only for testing)
-//    * continue=true, suppress=false:  processing continues, all messages printed (suitable only for testing)
-//    * continue=false, suppress=true:  processing stops at first message other than "unexpected element"; 
-//    *     all "unexpected element" messages suppressed (default)
-//    * continue=false, suppress=false:  processing stops at first message other than "unexpected element"; 
-//    *     all messages printed
-
+	public PetriNetValidationEventHandler() {
+		this(false, true); 
+	}
+	
 	
 	@Override
 	public boolean handleEvent(ValidationEvent event) {
@@ -97,6 +89,7 @@ public class PetriNetValidationEventHandler implements ValidationEventHandler {
 	public List<FormattedEvent> getFormattedEvents() {
 		return formattedEvents;
 	}
+	
 	protected class FormattedEvent {
 		public boolean unexpected; 
 		public String formattedEvent; 

--- a/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/PetriNetAdapter.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/PetriNetAdapter.java
@@ -22,8 +22,8 @@ public class PetriNetAdapter extends XmlAdapter<AdaptedPetriNet, PetriNet> {
         PetriNet petriNet = new PetriNet();
         addToPetriNet(v.tokens, petriNet);
         addToPetriNet(v.annotations, petriNet);
-        addToPetriNet(v.rateParameters, petriNet);
         addToPetriNet(v.places, petriNet);
+        addToPetriNet(v.rateParameters, petriNet);
         addToPetriNet(v.transitions, petriNet);
         addToPetriNet(v.arcs, petriNet);
         return petriNet;

--- a/src/main/java/uk/ac/imperial/pipe/visitor/ClonePetriNet.java
+++ b/src/main/java/uk/ac/imperial/pipe/visitor/ClonePetriNet.java
@@ -77,16 +77,16 @@ public final class ClonePetriNet {
             visit(token);
         }
 
-        for (RateParameter rateParameter : petriNet.getRateParameters()) {
-            visit(rateParameter);
-        }
-
         for (Annotation annotation : petriNet.getAnnotations()) {
             visit(annotation);
         }
 
         for (Place place : petriNet.getPlaces()) {
             visit(place);
+        }
+
+        for (RateParameter rateParameter : petriNet.getRateParameters()) {
+        	visit(rateParameter);
         }
 
         for (Transition transition : petriNet.getTransitions()) {

--- a/src/test/java/uk/ac/imperial/pipe/animation/PetriNetAnimationLogicTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/animation/PetriNetAnimationLogicTest.java
@@ -4,7 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.ac.imperial.pipe.dsl.*;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.InboundArc;
 import uk.ac.imperial.pipe.models.petrinet.Place;
 import uk.ac.imperial.pipe.models.petrinet.ColoredToken;
@@ -26,7 +27,7 @@ public class PetriNetAnimationLogicTest {
 
 
     @Test
-    public void infiniteServerSemantics() {
+    public void infiniteServerSemantics() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(2, "Default").tokens()).and(APlace.withId("P1").and(0, "Default").tokens()).and(
                 AnImmediateTransition.withId("T0").andIsAnInfinite()).and(
@@ -49,7 +50,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void multiColorArcsCanFire() throws PetriNetComponentNotFoundException {
+    public void multiColorArcsCanFire() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AToken.called("Red").withColor(Color.RED)).and(
                 APlace.withId("P0").containing(1, "Default").token().and(1, "Red").token()).and(
@@ -70,7 +71,7 @@ public class PetriNetAnimationLogicTest {
 
 
     @Test
-    public void multiColorArcsCanFireWithZeroWeighting() throws PetriNetComponentNotFoundException {
+    public void multiColorArcsCanFireWithZeroWeighting() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AToken.called("Red").withColor(Color.RED)).and(
                 APlace.withId("P0").containing(1, "Default").token().and(1, "Red").token()).and(
@@ -90,7 +91,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyIdentifiesEnabledTransition() throws PetriNetComponentNotFoundException {
+    public void correctlyIdentifiesEnabledTransition() throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
         Transition transition = petriNet.getComponent("T1", Transition.class);
@@ -105,8 +106,9 @@ public class PetriNetAnimationLogicTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimplePetriNet(int tokenWeight) {
+    public PetriNet createSimplePetriNet(int tokenWeight) throws PetriNetComponentException {
         String arcWeight = Integer.toString(tokenWeight);
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P1").containing(1, "Default").token()).and(APlace.withId("P2")).and(
@@ -116,7 +118,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyIdentifiesEnabledWithNoSecondColourToken() throws PetriNetComponentNotFoundException {
+    public void correctlyIdentifiesEnabledWithNoSecondColourToken() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AToken.called("Red").withColor(Color.RED)).and(
                 APlace.withId("P1").containing(1, "Red").token().and(1, "Default").token()).and(
@@ -131,7 +133,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyIdentifiesNotEnabledTransitionDueToEmptyPlace() throws PetriNetComponentNotFoundException {
+    public void correctlyIdentifiesNotEnabledTransitionDueToEmptyPlace() throws PetriNetComponentException {
         int tokenWeight = 4;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
         Place place = petriNet.getComponent("P1", Place.class);
@@ -145,7 +147,7 @@ public class PetriNetAnimationLogicTest {
 
     @Test
     public void correctlyIdentifiesNotEnabledTransitionDueToNotEnoughTokens()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         int tokenWeight = 4;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
         Transition transition = petriNet.getComponent("T1", Transition.class);
@@ -157,7 +159,7 @@ public class PetriNetAnimationLogicTest {
 
     @Test
     public void correctlyIdentifiesNotEnabledTransitionDueToOnePlaceNotEnoughTokens()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNetTwoPlacesToTransition(tokenWeight);
         Transition transition = petriNet.getComponent("T1", Transition.class);
@@ -173,8 +175,9 @@ public class PetriNetAnimationLogicTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimplePetriNetTwoPlacesToTransition(int tokenWeight) {
+    public PetriNet createSimplePetriNetTwoPlacesToTransition(int tokenWeight) throws PetriNetComponentException {
         String weight = Integer.toString(tokenWeight);
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P1")).and(
                 APlace.withId("P2")).and(AnImmediateTransition.withId("T1")).and(
@@ -184,7 +187,7 @@ public class PetriNetAnimationLogicTest {
 
     @Test
     public void correctlyIdentifiesNotEnabledTransitionDueToArcNeedingTwoDifferentTokens()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
 
@@ -201,7 +204,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyIdentifiesEnabledTransitionRequiringTwoTokens() throws PetriNetComponentNotFoundException {
+    public void correctlyIdentifiesEnabledTransitionRequiringTwoTokens() throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
 
@@ -236,7 +239,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyDoesNotEnableTransitionsIfPlaceCapacityIsFull() throws PetriNetComponentNotFoundException {
+    public void correctlyDoesNotEnableTransitionsIfPlaceCapacityIsFull() throws PetriNetComponentException {
         PetriNet petriNet = createSimplePetriNet(2);
         Token token = petriNet.getComponent("Default", Token.class);
 
@@ -253,7 +256,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyEnablesTransitionIfSelfLoop() throws PetriNetComponentNotFoundException {
+    public void correctlyEnablesTransitionIfSelfLoop() throws PetriNetComponentException {
         PetriNet petriNet = createSelfLoopPetriNet("1");
         Place place = petriNet.getComponent("P0", Place.class);
         Token token = petriNet.getComponent("Default", Token.class);
@@ -267,7 +270,7 @@ public class PetriNetAnimationLogicTest {
         assertThat(enabled).containsExactly(transition);
     }
 
-    private PetriNet createSelfLoopPetriNet(String tokenWeight) {
+    private PetriNet createSelfLoopPetriNet(String tokenWeight) throws PetriNetComponentException {
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                 AnImmediateTransition.withId("T1")).and(
                 ANormalArc.withSource("T1").andTarget("P0").with(tokenWeight, "Default").tokens()).andFinally(
@@ -275,7 +278,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void correctlyMarksInhibitorArcEnabledTransition() throws PetriNetComponentNotFoundException {
+    public void correctlyMarksInhibitorArcEnabledTransition() throws PetriNetComponentException {
         PetriNet petriNet = createSimpleInhibitorPetriNet(1);
         Transition transition = petriNet.getComponent("T1", Transition.class);
         AnimationLogic animator = new PetriNetAnimationLogic(petriNet);
@@ -289,8 +292,9 @@ public class PetriNetAnimationLogicTest {
      *
      * @param tokenWeight
      * @return simple Petri net with P1 -o T1 -> P2
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimpleInhibitorPetriNet(int tokenWeight) {
+    public PetriNet createSimpleInhibitorPetriNet(int tokenWeight) throws PetriNetComponentException {
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P1")).and(
                 APlace.withId("P2")).and(AnImmediateTransition.withId("T1")).and(
                 AnInhibitorArc.withSource("P1").andTarget("T1")).andFinally(
@@ -298,7 +302,7 @@ public class PetriNetAnimationLogicTest {
     }
 
     @Test
-    public void calculatesSimpleSuccessorStates() {
+    public void calculatesSimpleSuccessorStates() throws PetriNetComponentException {
         PetriNet petriNet = createSimplePetriNet(1);
         State state = AnimationUtils.getState(petriNet);
         AnimationLogic animator = new PetriNetAnimationLogic(petriNet);
@@ -316,7 +320,7 @@ public class PetriNetAnimationLogicTest {
 
 
     @Test
-    public void calculatesSelfLoop() {
+    public void calculatesSelfLoop() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(1, "Default").token()).and(AnImmediateTransition.withId("T0")).and(
                 ANormalArc.withSource("P0").andTarget("T0").with("1", "Default").token()).andFinally(
@@ -336,9 +340,10 @@ public class PetriNetAnimationLogicTest {
     /**
      * If a state contains Integer.MAX_VALUE then this is considered to be infinite
      * so infinity addition and subtraction rules should apply
+     * @throws PetriNetComponentException 
      */
     @Test
-    public void infinityLogic() {
+    public void infinityLogic() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AnImmediateTransition.withId("T0")).andFinally(APlace.withId("P0").and(Integer.MAX_VALUE, "Default").token());
 

--- a/src/test/java/uk/ac/imperial/pipe/animation/PetriNetAnimatorTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/animation/PetriNetAnimatorTest.java
@@ -2,7 +2,7 @@ package uk.ac.imperial.pipe.animation;
 
 import org.junit.Test;
 import uk.ac.imperial.pipe.dsl.*;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.Place;
 import uk.ac.imperial.pipe.models.petrinet.Token;
 import uk.ac.imperial.pipe.models.petrinet.Transition;
@@ -21,7 +21,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void correctlyIncrementsTokenCountInSelfLoop() throws PetriNetComponentNotFoundException {
+    public void correctlyIncrementsTokenCountInSelfLoop() throws PetriNetComponentException {
 
         PetriNet petriNet = createSelfLoopPetriNet("1");
         Place place = petriNet.getComponent("P0", Place.class);
@@ -36,7 +36,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void firingFunctionalTransitionMovesTokens() throws PetriNetComponentNotFoundException {
+    public void firingFunctionalTransitionMovesTokens() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Red").withColor(Color.RED)).and(
                 AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").containing(5, "Default").tokens()).and(APlace.withId("P1")).and(
@@ -56,7 +56,7 @@ public class PetriNetAnimatorTest {
     }
 
     @Test
-    public void firingTransitionDoesNotDisableTransition() throws PetriNetComponentNotFoundException {
+    public void firingTransitionDoesNotDisableTransition() throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
         Place place = petriNet.getComponent("P1", Place.class);
@@ -73,7 +73,7 @@ public class PetriNetAnimatorTest {
     }
 
     @Test
-    public void firingTransitionEnablesNextTransition() throws PetriNetComponentNotFoundException {
+    public void firingTransitionEnablesNextTransition() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P1").containing(1, "Default").token()).and(APlace.withId("P2")).and(
                 AnImmediateTransition.withId("T1")).and(AnImmediateTransition.withId("T2")).and(
@@ -91,7 +91,7 @@ public class PetriNetAnimatorTest {
         assertThat(enabled).contains(transition2);
     }
     @Test
-    public void randomTransitionsReturnsSingleEligibleTransition() throws PetriNetComponentNotFoundException {
+    public void randomTransitionsReturnsSingleEligibleTransition() throws PetriNetComponentException {
     	// PN with single enabled transition
     	PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
     			APlace.withId("P1").containing(1, "Default").token()).
@@ -106,7 +106,7 @@ public class PetriNetAnimatorTest {
     	assertEquals("T1", t.getId()); 
     }
     @Test
-    public void randomTransitionsIncludesAllEligibleTransitionsInRoughProportion() throws PetriNetComponentNotFoundException {
+    public void randomTransitionsIncludesAllEligibleTransitionsInRoughProportion() throws PetriNetComponentException {
     	// PN with two enabled transitions
     	PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
     			APlace.withId("P1").containing(1, "Default").token()).
@@ -131,7 +131,7 @@ public class PetriNetAnimatorTest {
     }
 
     @Test
-    public void firingTransitionBackwardMovesTokensBack() throws PetriNetComponentNotFoundException {
+    public void firingTransitionBackwardMovesTokensBack() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P1").containing(0, "Default").token()).and(AnImmediateTransition.withId("T1")).andFinally(
                 ANormalArc.withSource("P1").andTarget("T1").with("1", "Default").token());
@@ -149,7 +149,7 @@ public class PetriNetAnimatorTest {
 
 
 
-    private PetriNet createSelfLoopPetriNet(String tokenWeight) {
+    private PetriNet createSelfLoopPetriNet(String tokenWeight) throws PetriNetComponentException {
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                 AnImmediateTransition.withId("T1")).and(
                 ANormalArc.withSource("T1").andTarget("P0").with(tokenWeight, "Default").tokens()).andFinally(
@@ -159,7 +159,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void correctlyEnablesTransitionEvenAfterFiring() throws PetriNetComponentNotFoundException {
+    public void correctlyEnablesTransitionEvenAfterFiring() throws PetriNetComponentException {
         PetriNet petriNet = createSimpleInhibitorPetriNet(1);
         Transition transition = petriNet.getComponent("T1", Transition.class);
 
@@ -172,7 +172,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void firingTransitionMovesToken() throws PetriNetComponentNotFoundException {
+    public void firingTransitionMovesToken() throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
 
@@ -194,8 +194,9 @@ public class PetriNetAnimatorTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimpleInhibitorPetriNet(int tokenWeight) {
+    public PetriNet createSimpleInhibitorPetriNet(int tokenWeight) throws PetriNetComponentException {
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P1")).and(
                 APlace.withId("P2")).and(AnImmediateTransition.withId("T1")).and(
                 AnInhibitorArc.withSource("P1").andTarget("T1")).andFinally(
@@ -204,7 +205,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void firingTransitionDisablesTransition() throws PetriNetComponentNotFoundException {
+    public void firingTransitionDisablesTransition() throws PetriNetComponentException {
         int tokenWeight = 1;
         PetriNet petriNet = createSimplePetriNet(tokenWeight);
 
@@ -218,7 +219,7 @@ public class PetriNetAnimatorTest {
 
 
     @Test
-    public void firingTransitionBackwardEnablesTransition() throws PetriNetComponentNotFoundException {
+    public void firingTransitionBackwardEnablesTransition() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P1")).and(
                         APlace.withId("P2").containing(1, "Default").token()).and(AnImmediateTransition.withId("T1")).andFinally(
@@ -233,7 +234,7 @@ public class PetriNetAnimatorTest {
     }
 
     @Test
-    public void restoresPetriNet() {
+    public void restoresPetriNet() throws PetriNetComponentException {
         PetriNet petriNet = createSimplePetriNet(1);
         PetriNet copy = ClonePetriNet.clone(petriNet);
 
@@ -251,8 +252,9 @@ public class PetriNetAnimatorTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimplePetriNet(int tokenWeight) {
+    public PetriNet createSimplePetriNet(int tokenWeight) throws PetriNetComponentException {
         String arcWeight = Integer.toString(tokenWeight);
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P1").containing(1, "Default").token()).and(APlace.withId("P2")).and(

--- a/src/test/java/uk/ac/imperial/pipe/io/PetriNetWriterTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/PetriNetWriterTest.java
@@ -112,7 +112,7 @@ public class PetriNetWriterTest extends XMLTestCase {
         assertResultsEqual(FileUtils.fileLocation(XMLUtils.getTransitionRateParameterFile()), petriNet);
     }
 
-    public void testMarshalsArc() throws IOException, SAXException, JAXBException {
+    public void testMarshalsArc() throws IOException, SAXException, JAXBException, PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").locatedAt(0, 0)).and(AnImmediateTransition.withId("T0").locatedAt(0, 0)).andFinally(
                 ANormalArc.withSource("P0").andTarget("T0").and("4", "Default").tokens());

--- a/src/test/java/uk/ac/imperial/pipe/io/XMLUtils.java
+++ b/src/test/java/uk/ac/imperial/pipe/io/XMLUtils.java
@@ -62,12 +62,19 @@ public class XMLUtils {
     public static String getTwoTokenFile() {
     	return "/xml/token/two_token.xml";
     }
+    public static String getRateParameterReferencesPlaceFile() {
+    	return "/xml/rateParameter/rateReferencesPlace.xml";
+    }
+    
+    public static String getNoPlaceTokenPath() {
+    	return "/xml/place/noTokenPlace.xml";
+    }
+
     public static String readFile(String path, Charset encoding)
             throws IOException
     {
         byte[] encoded = Files.readAllBytes(Paths.get(path));
         return encoding.decode(ByteBuffer.wrap(encoded)).toString();
     }
-
 
 }

--- a/src/test/java/uk/ac/imperial/pipe/models/DiscreteTransitionTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/models/DiscreteTransitionTest.java
@@ -1,18 +1,28 @@
 package uk.ac.imperial.pipe.models;
 
-import org.junit.Test;
-import uk.ac.imperial.pipe.animation.AnimationUtils;
-import uk.ac.imperial.pipe.dsl.*;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
-import uk.ac.imperial.pipe.models.petrinet.*;
-import uk.ac.imperial.state.State;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.awt.Color;
 import java.awt.geom.Point2D;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import org.junit.Test;
+
+import uk.ac.imperial.pipe.animation.AnimationUtils;
+import uk.ac.imperial.pipe.dsl.ANormalArc;
+import uk.ac.imperial.pipe.dsl.APetriNet;
+import uk.ac.imperial.pipe.dsl.APlace;
+import uk.ac.imperial.pipe.dsl.ATimedTransition;
+import uk.ac.imperial.pipe.dsl.AToken;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.models.petrinet.DiscreteTransition;
+import uk.ac.imperial.pipe.models.petrinet.DiscreteTransitionVisitor;
+import uk.ac.imperial.pipe.models.petrinet.PetriNet;
+import uk.ac.imperial.pipe.models.petrinet.Transition;
+import uk.ac.imperial.pipe.models.petrinet.TransitionVisitor;
+import uk.ac.imperial.state.State;
 
 public class DiscreteTransitionTest {
 
@@ -147,7 +157,7 @@ public class DiscreteTransitionTest {
 
     @Test
     public void infiniteServerRateMultipliesByEnablingDegreeNonFunctionalArc()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(5, "Default").tokens()).and(APlace.withId("P1").and(2, "Default").tokens()).and(
                 ATimedTransition.withId("T0").andIsAnInfinite().server().andRate("4")).and(
@@ -164,7 +174,7 @@ public class DiscreteTransitionTest {
 
     @Test
     public void infiniteServerRateMultipliesByEnablingDegreeFunctionalArcs()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(5, "Default").tokens()).and(APlace.withId("P1").and(2, "Default").tokens()).and(
                 ATimedTransition.withId("T0").andIsAnInfinite().server().andRate("4")).and(
@@ -182,7 +192,7 @@ public class DiscreteTransitionTest {
 
     @Test
     public void actualRateSingleServer()
-            throws PetriNetComponentNotFoundException {
+            throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(5, "Default").tokens()).and(APlace.withId("P1").and(2, "Default").tokens()).and(
                 ATimedTransition.withId("T0").andIsASingle().server().andRate("4")).and(
@@ -222,7 +232,7 @@ public class DiscreteTransitionTest {
     }
 
     @Test
-    public void evaluatesRateAgainstPetriNet() throws PetriNetComponentNotFoundException {
+    public void evaluatesRateAgainstPetriNet() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(5, "Default").tokens()).and(
                 ATimedTransition.withId("T0").andIsASingle().server().andRate("#(P0)")).andFinally(

--- a/src/test/java/uk/ac/imperial/pipe/models/PetriNetTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/models/PetriNetTest.java
@@ -10,7 +10,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.ac.imperial.pipe.dsl.*;
 import uk.ac.imperial.pipe.exceptions.InvalidRateException;
 import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.*;
 
 import java.awt.Color;
@@ -289,7 +289,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void returnsCorrectToken() throws PetriNetComponentNotFoundException {
+    public void returnsCorrectToken() throws PetriNetComponentException {
         String id = "Token1";
         Color color = new Color(132, 16, 130);
         Token token = new ColoredToken(id, color);
@@ -298,8 +298,8 @@ public class PetriNetTest {
     }
 
     @Test
-    public void throwsErrorIfNoTokenExists() throws PetriNetComponentNotFoundException {
-        expectedException.expect(PetriNetComponentNotFoundException.class);
+    public void throwsErrorIfNoTokenExists() throws PetriNetComponentException {
+        expectedException.expect(PetriNetComponentException.class);
         expectedException.expectMessage("No component foo exists in Petri net");
         net.getComponent("foo", Token.class);
     }
@@ -318,8 +318,9 @@ public class PetriNetTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimplePetriNetTwoPlacesToTransition(int tokenWeight) {
+    public PetriNet createSimplePetriNetTwoPlacesToTransition(int tokenWeight) throws PetriNetComponentException {
         String weight = Integer.toString(tokenWeight);
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P1")).and(
                 APlace.withId("P2")).and(AnImmediateTransition.withId("T1")).and(
@@ -344,7 +345,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void testEqualityEqualPetriNets() {
+    public void testEqualityEqualPetriNets() throws PetriNetComponentException {
         PetriNet net1 = createSimplePetriNet(1);
         PetriNet net2 = createSimplePetriNet(1);
         assertTrue(net1.equals(net2));
@@ -356,8 +357,9 @@ public class PetriNetTest {
      *
      * @param tokenWeight
      * @return
+     * @throws PetriNetComponentException 
      */
-    public PetriNet createSimplePetriNet(int tokenWeight) {
+    public PetriNet createSimplePetriNet(int tokenWeight) throws PetriNetComponentException {
         String arcWeight = Integer.toString(tokenWeight);
         return APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P1").containing(1, "Default").token()).and(APlace.withId("P2")).and(
@@ -367,14 +369,14 @@ public class PetriNetTest {
     }
 
     @Test
-    public void testEqualityNotEqualPetriNets() {
+    public void testEqualityNotEqualPetriNets() throws PetriNetComponentException {
         PetriNet net1 = createSimplePetriNet(1);
         PetriNet net2 = createSimplePetriNet(4);
         assertFalse(net1.equals(net2));
     }
 
     @Test
-    public void equalsAndHashCodeLawsWhenEqual() {
+    public void equalsAndHashCodeLawsWhenEqual() throws PetriNetComponentException {
         PetriNet net1 = createSimplePetriNet(1);
         PetriNet net2 = createSimplePetriNet(1);
         assertTrue(net1.equals(net2));
@@ -382,21 +384,21 @@ public class PetriNetTest {
     }
 
     @Test
-    public void equalsAndHashCodeLawsWhenNotEqual() {
+    public void equalsAndHashCodeLawsWhenNotEqual() throws PetriNetComponentException {
         PetriNet net1 = createSimplePetriNet(1);
         PetriNet net2 = createSimplePetriNet(5);
         assertFalse(net1.equals(net2));
     }
 
     @Test
-    public void canGetTokenById() throws PetriNetComponentNotFoundException {
+    public void canGetTokenById() throws PetriNetComponentException {
         Token t = new ColoredToken("Default", Color.BLACK);
         net.addToken(t);
         assertEquals(t, net.getComponent(t.getId(), Token.class));
     }
 
     @Test
-    public void canGetTokenByIdAfterNameChange() throws PetriNetComponentNotFoundException {
+    public void canGetTokenByIdAfterNameChange() throws PetriNetComponentException {
         Token t = new ColoredToken("Default", Color.BLACK);
         net.addToken(t);
         t.setId("Red");
@@ -404,14 +406,14 @@ public class PetriNetTest {
     }
 
     @Test
-    public void canGetPlaceById() throws PetriNetComponentNotFoundException {
+    public void canGetPlaceById() throws PetriNetComponentException {
         Place p = new DiscretePlace("P0", "P0");
         net.addPlace(p);
         assertEquals(p, net.getComponent(p.getId(), Place.class));
     }
 
     @Test
-    public void canGetPlaceByIdAfterIdChange() throws PetriNetComponentNotFoundException {
+    public void canGetPlaceByIdAfterIdChange() throws PetriNetComponentException {
         Place p = new DiscretePlace("P0", "P0");
         net.addPlace(p);
         p.setId("P1");
@@ -419,14 +421,14 @@ public class PetriNetTest {
     }
 
     @Test
-    public void canGetRateParameterById() throws PetriNetComponentNotFoundException, InvalidRateException {
+    public void canGetRateParameterById() throws PetriNetComponentException, InvalidRateException {
         FunctionalRateParameter r = new FunctionalRateParameter("2", "R0", "R0");
         net.addRateParameter(r);
         assertEquals(r, net.getComponent(r.getId(), RateParameter.class));
     }
 
     @Test
-    public void canGetRateParameterByIdAfterIdChange() throws PetriNetComponentNotFoundException, InvalidRateException {
+    public void canGetRateParameterByIdAfterIdChange() throws PetriNetComponentException, InvalidRateException {
         FunctionalRateParameter r = new FunctionalRateParameter("2", "R0", "R0");
         net.addRateParameter(r);
         r.setId("R1");
@@ -434,14 +436,14 @@ public class PetriNetTest {
     }
 
     @Test
-    public void canGetTransitionById() throws PetriNetComponentNotFoundException {
+    public void canGetTransitionById() throws PetriNetComponentException {
         Transition t = new DiscreteTransition("T0", "T0");
         net.addTransition(t);
         assertEquals(t, net.getComponent(t.getId(), Transition.class));
     }
 
     @Test
-    public void canGetTransitionByIdAfterNameChange() throws PetriNetComponentNotFoundException {
+    public void canGetTransitionByIdAfterNameChange() throws PetriNetComponentException {
         Transition t = new DiscreteTransition("T0", "T0");
         net.addTransition(t);
         t.setId("T2");
@@ -449,7 +451,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void canGetArcById() throws PetriNetComponentNotFoundException {
+    public void canGetArcById() throws PetriNetComponentException {
         Place p = new DiscretePlace("P0", "P0");
         Transition t = new DiscreteTransition("T0", "T0");
         InboundArc a = new InboundNormalArc(p, t, new HashMap<String, String>());
@@ -458,7 +460,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void canGetArcByIdAfterNameChange() throws PetriNetComponentNotFoundException {
+    public void canGetArcByIdAfterNameChange() throws PetriNetComponentException {
         Place p = new DiscretePlace("P0", "P0");
         Transition t = new DiscreteTransition("T0", "T0");
         InboundArc a = new InboundNormalArc(p, t, new HashMap<String, String>());
@@ -502,7 +504,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void correctEmptyOutboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctEmptyOutboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).andFinally(
                         AnImmediateTransition.withId("T0"));
@@ -512,7 +514,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void correctEmptyInboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctEmptyInboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).andFinally(
                         AnImmediateTransition.withId("T0"));
@@ -522,7 +524,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void removesTransitionInboundWhenDeleted() throws PetriNetComponentNotFoundException {
+    public void removesTransitionInboundWhenDeleted() throws PetriNetComponentException {
         PetriNet petriNet =
 
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
@@ -539,7 +541,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void correctInboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctInboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
 
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
@@ -554,7 +556,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void correctDeletesFromInboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctDeletesFromInboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         AnImmediateTransition.withId("T0")).andFinally(
@@ -567,7 +569,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void correctOutboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctOutboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -582,7 +584,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void removesAllOutBoundWhenTransitionDeleted() throws PetriNetComponentNotFoundException {
+    public void removesAllOutBoundWhenTransitionDeleted() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -596,7 +598,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void correctOutboundArcsIfTransitionChangesName() throws PetriNetComponentNotFoundException {
+    public void correctOutboundArcsIfTransitionChangesName() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -613,7 +615,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void correctRemovalDeletesFromOutboundArcs() throws PetriNetComponentNotFoundException {
+    public void correctRemovalDeletesFromOutboundArcs() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         AnImmediateTransition.withId("T0")).andFinally(
@@ -626,7 +628,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void cannotDeletePlaceIfReferencedByTransition() throws PetriNetComponentNotFoundException {
+    public void cannotDeletePlaceIfReferencedByTransition() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(APlace.withId("P0")).andFinally(
                 ATimedTransition.withId("T0").andRate("#(P0)"));
         Place place = petriNet.getComponent("P0", Place.class);
@@ -642,7 +644,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void cannotDeletePlaceIfReferencedByRateParam() throws PetriNetComponentNotFoundException {
+    public void cannotDeletePlaceIfReferencedByRateParam() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(APlace.withId("P0")).andFinally(ARateParameter.withId("R1").andExpression("#(P0)"));
         Place place = petriNet.getComponent("P0", Place.class);
         try {
@@ -656,7 +658,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void cannotDeletePlaceIfReferencedByArc() throws PetriNetComponentNotFoundException {
+    public void cannotDeletePlaceIfReferencedByArc() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -675,7 +677,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void allComponents() {
+    public void allComponents() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -689,7 +691,7 @@ public class PetriNetTest {
 
 
     @Test
-    public void containsComponents() {
+    public void containsComponents() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(
@@ -703,7 +705,7 @@ public class PetriNetTest {
     }
 
     @Test
-    public void doesNotContainComponents() {
+    public void doesNotContainComponents() throws PetriNetComponentException {
         PetriNet petriNet =
                 APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                         APlace.withId("P1")).and(AnImmediateTransition.withId("T0")).and(

--- a/src/test/java/uk/ac/imperial/pipe/parsers/EvalVisitorTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/parsers/EvalVisitorTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import uk.ac.imperial.pipe.dsl.APetriNet;
 import uk.ac.imperial.pipe.dsl.APlace;
 import uk.ac.imperial.pipe.dsl.AToken;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 
 import java.awt.Color;
@@ -150,7 +150,7 @@ public class EvalVisitorTest {
 
 
     @Test
-    public void parsesPlaceTokenNumber() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceTokenNumber() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").and(4, "Default").tokens());
 
@@ -163,7 +163,7 @@ public class EvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceColorTokenNumber() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceColorTokenNumber() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AToken.called("Red").withColor(Color.RED)).andFinally(
                 APlace.withId("P0").and(4, "Default").tokens().and(6, "Red").tokens());
@@ -176,7 +176,7 @@ public class EvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceTokenNumberAsZeroIfDoesNotExist() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceTokenNumberAsZeroIfDoesNotExist() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").and(4, "Default").tokens());
 
@@ -189,7 +189,7 @@ public class EvalVisitorTest {
 
 
     @Test
-    public void parsesPlaceCapacity() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceCapacity() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").andCapacity(10));
 
@@ -202,7 +202,7 @@ public class EvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceCapacityAsZeroIfDoesNotExist() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceCapacityAsZeroIfDoesNotExist() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").andCapacity(10));
 

--- a/src/test/java/uk/ac/imperial/pipe/parsers/PetriNetWeightParserTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/parsers/PetriNetWeightParserTest.java
@@ -7,6 +7,7 @@ import org.junit.rules.ExpectedException;
 import uk.ac.imperial.pipe.dsl.APetriNet;
 import uk.ac.imperial.pipe.dsl.APlace;
 import uk.ac.imperial.pipe.dsl.AToken;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 
 import java.awt.Color;
@@ -58,7 +59,7 @@ public class PetriNetWeightParserTest {
 
 
     @Test
-    public void willNotEvaluateExpressionIfPetriNetDoesNotContainComponent() throws UnparsableException {
+    public void willNotEvaluateExpressionIfPetriNetDoesNotContainComponent() throws UnparsableException, PetriNetComponentException {
         PetriNet petriNet = APetriNet.withOnly(APlace.withId("P1"));
         FunctionalWeightParser<Double> parser = new PetriNetWeightParser(evalVisitor, petriNet);
         FunctionalResults<Double> result = parser.evaluateExpression("#(P0)");
@@ -68,7 +69,7 @@ public class PetriNetWeightParserTest {
 
 
     @Test
-    public void evaluatesIfPlaceIsInPetriNet() throws UnparsableException {
+    public void evaluatesIfPlaceIsInPetriNet() throws UnparsableException, PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(APlace.withId("P0").containing(10, "Default").tokens());
 
         EvalVisitor evalVisitor = new EvalVisitor(petriNet);
@@ -78,7 +79,7 @@ public class PetriNetWeightParserTest {
     }
 
     @Test
-    public void returnsCorrectComponentsForTotalTokens() {
+    public void returnsCorrectComponentsForTotalTokens() throws PetriNetComponentException {
 
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(APlace.withId("P0").containing(10, "Default").tokens());
         EvalVisitor evalVisitor = new EvalVisitor(petriNet);
@@ -89,7 +90,7 @@ public class PetriNetWeightParserTest {
 
 
     @Test
-    public void returnsCorrectComponentsForSpecificTokens() {
+    public void returnsCorrectComponentsForSpecificTokens() throws PetriNetComponentException {
 
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(APlace.withId("P0").containing(10, "Default").tokens());
 

--- a/src/test/java/uk/ac/imperial/pipe/parsers/StateEvalVisitorTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/parsers/StateEvalVisitorTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import uk.ac.imperial.pipe.dsl.APetriNet;
 import uk.ac.imperial.pipe.dsl.APlace;
 import uk.ac.imperial.pipe.dsl.AToken;
-import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 import uk.ac.imperial.state.HashedState;
 import uk.ac.imperial.state.HashedStateBuilder;
@@ -157,7 +157,7 @@ public class StateEvalVisitorTest {
 
 
     @Test
-    public void parsesPlaceTokenNumber() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceTokenNumber() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0"));
         HashedStateBuilder builder = new HashedStateBuilder();
@@ -173,7 +173,7 @@ public class StateEvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceColorTokenNumber() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceColorTokenNumber() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 AToken.called("Red").withColor(Color.RED)).andFinally(
                 APlace.withId("P0"));
@@ -192,7 +192,7 @@ public class StateEvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceTokenNumberAsZeroIfDoesNotExist() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceTokenNumberAsZeroIfDoesNotExist() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0"));
 
@@ -209,7 +209,7 @@ public class StateEvalVisitorTest {
 
 
     @Test
-    public void parsesPlaceCapacity() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceCapacity() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").andCapacity(10));
 
@@ -226,7 +226,7 @@ public class StateEvalVisitorTest {
     }
 
     @Test
-    public void parsesPlaceCapacityAsZeroIfDoesNotExist() throws PetriNetComponentNotFoundException {
+    public void parsesPlaceCapacityAsZeroIfDoesNotExist() throws PetriNetComponentException {
         PetriNet petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).andFinally(
                 APlace.withId("P0").andCapacity(10));
 

--- a/src/test/java/uk/ac/imperial/pipe/petrinet/unfold/ExpanderTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/petrinet/unfold/ExpanderTest.java
@@ -94,7 +94,7 @@ public class ExpanderTest {
     }
 
     @Test
-    public void singleTokenPetriNetIsExpandedToItself() {
+    public void singleTokenPetriNetIsExpandedToItself() throws PetriNetComponentException {
         petriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(APlace.withId("P0")).and(
                 AnImmediateTransition.withId("T0")).andFinally(
                 ANormalArc.withSource("P0").andTarget("T0").with("2", "Default").tokens());

--- a/src/test/java/uk/ac/imperial/pipe/visitor/ClonePetriNetTest.java
+++ b/src/test/java/uk/ac/imperial/pipe/visitor/ClonePetriNetTest.java
@@ -3,9 +3,11 @@ package uk.ac.imperial.pipe.visitor;
 import org.junit.Before;
 import org.junit.Test;
 import uk.ac.imperial.pipe.dsl.*;
+import uk.ac.imperial.pipe.exceptions.PetriNetComponentException;
 import uk.ac.imperial.pipe.exceptions.PetriNetComponentNotFoundException;
 import uk.ac.imperial.pipe.models.petrinet.InboundArc;
 import uk.ac.imperial.pipe.models.petrinet.Place;
+import uk.ac.imperial.pipe.models.petrinet.RateParameter;
 import uk.ac.imperial.pipe.models.petrinet.Transition;
 import uk.ac.imperial.pipe.models.petrinet.PetriNet;
 import uk.ac.imperial.pipe.models.petrinet.name.NormalPetriNetName;
@@ -22,7 +24,7 @@ public class ClonePetriNetTest {
     PetriNet clonedPetriNet;
 
     @Before
-    public void setUp() {
+    public void setUp() throws PetriNetComponentException {
         oldPetriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
                 APlace.withId("P0").and(1, "Default").token()).and(APlace.withId("P1")).and(
                 ATimedTransition.withId("T0")).and(ATimedTransition.withId("T1"))
@@ -64,4 +66,21 @@ public class ClonePetriNetTest {
         assertTrue(arc.getSource() == clonedP0);
         assertTrue(arc.getTarget() == clonedT0);
     }
+    @Test
+    public void clonesRateParameter() throws PetriNetComponentException {
+	    checkRateParameter("3");
+    }
+    @Test
+    public void clonesRateParameterReferencingPlace() throws PetriNetComponentException {
+    	checkRateParameter("#(P0)");
+    }
+	protected void checkRateParameter(String rateExpression)
+			throws PetriNetComponentException {
+		oldPetriNet = APetriNet.with(AToken.called("Default").withColor(Color.BLACK)).and(
+				APlace.withId("P0").and(1, "Default").token()).andFinally(
+				ARateParameter.withId("rate1").andExpression(rateExpression)); 
+    	clonedPetriNet = ClonePetriNet.clone(oldPetriNet);
+    	RateParameter rate = clonedPetriNet.getComponent("rate1", RateParameter.class);
+    	assertEquals(rateExpression, rate.getExpression());
+	}
 }

--- a/src/test/resources/xml/invalidPetriNet.xml
+++ b/src/test/resources/xml/invalidPetriNet.xml
@@ -2,26 +2,6 @@
 <pnml>
     <net id="invalid" type="fred">
         <blah/>
-        <token id="Default" enabled="true" red="0" green="0" blue="0"/>
-        <place id="P0">
-            <graphics>
-                <position x="225.0" y="240.0"/>
-            </graphics>
-            <name>
-                <value>P0</value>
-                <graphics>
-                    <offset x="0.0" y="0.0"/>
-                </graphics>
-            </name>
-            <initialMarking>
-                <value>Default,1</value>
-                <graphics>
-                    <offset x="0.0" y="0.0"/>
-                </graphics>
-            </initialMarking>
-            <capacity>
-                <value>0</value>
-            </capacity>
-        </place>
+	    <!-- blah tag will cause "unexpected element" error -->
     </net>
 </pnml>

--- a/src/test/resources/xml/rateParameter/rateReferencesPlace.xml
+++ b/src/test/resources/xml/rateParameter/rateReferencesPlace.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pnml>
+    <net>
+        <token id="Default" red="0" green="0" blue="0"/>
+        <definition name="rate1" expression="#(P0)" id="rate1" defType="real" type="text"/>
+        <place id="P1">
+            <graphics>
+                <position x="422.0" y="165.0"/>
+            </graphics>
+            <name>
+                <value>P1</value>
+                <graphics>
+                    <offset x="-5.0" y="35.0"/>
+                </graphics>
+            </name>
+            <capacity>
+                <value>0</value>
+            </capacity>
+            <initialMarking>
+                <graphics>
+                    <offset x="0.0" y="0.0"/>
+                </graphics>
+                <value></value>
+            </initialMarking>
+        </place>
+        <place id="P0">
+            <graphics>
+                <position x="225.0" y="165.0"/>
+            </graphics>
+            <name>
+                <value>P0</value>
+                <graphics>
+                    <offset x="-5.0" y="35.0"/>
+                </graphics>
+            </name>
+            <capacity>
+                <value>0</value>
+            </capacity>
+            <initialMarking>
+                <graphics>
+                    <offset x="0.0" y="0.0"/>
+                </graphics>
+                <value>Default,1</value>
+            </initialMarking>
+        </place>
+        <transition id="T0">
+            <graphics>
+                <position x="340.0" y="165.0"/>
+            </graphics>
+            <name>
+                <value>T0</value>
+                <graphics>
+                    <offset x="-5.0" y="35.0"/>
+                </graphics>
+            </name>
+            <infiniteServer>
+                <value>false</value>
+            </infiniteServer>
+            <timed>
+                <value>true</value>
+            </timed>
+            <priority>
+                <value>1</value>
+            </priority>
+            <orientation>
+                <value>0</value>
+            </orientation>
+            <rate>
+                <value>1</value>
+            </rate>
+        </transition>
+        <arc id="T0 TO P1" source="T0" target="P1">
+            <arcpath id="" x="350.0" y="180.0" curvePoint="false"/>
+            <arcpath id="" x="422.0" y="180.0" curvePoint="false"/>
+            <type value="normal"/>
+            <inscription>
+                <value>Default,1</value>
+            </inscription>
+        </arc>
+        <arc id="P0 TO T0" source="P0" target="T0">
+            <arcpath id="" x="255.0" y="180.0" curvePoint="false"/>
+            <arcpath id="" x="340.0" y="180.0" curvePoint="false"/>
+            <type value="normal"/>
+            <inscription>
+                <value>Default,1</value>
+            </inscription>
+        </arc>
+    </net>
+</pnml>


### PR DESCRIPTION
and DSL tests

added PetriNetComponentException to various DSL methods, so exceptions during rate parameter
processing would be visible.

PetriNetComponentNotFoundException is now a subtype of PetriNetComponentException