### PR TITLE
correct release 1.0.2 pom: pipe-markov-chain to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.imperial</groupId>
     <artifactId>pipe-core</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>uk.ac.imperial</groupId>
             <artifactId>pipe-markov-chain</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Corrected dependency on pipe-markov-chain to be 1.0.1