### PR TITLE
Fixed removing of a transition (inbound arcs were not removed).

### DIFF
--- a/src/main/java/uk/ac/imperial/pipe/models/petrinet/PetriNet.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/petrinet/PetriNet.java
@@ -239,6 +239,9 @@ public class PetriNet extends AbstractPetriNet {
         for (OutboundArc arc : outboundArcs(transition)) {
             removeArc(arc);
         }
+        for (InboundArc arc : inboundArcs(transition)) {
+            removeArc(arc);
+        }
         transitionOutboundArcs.removeAll(transition.getId());
         transitionInboundArcs.removeAll(transition.getId());
         changeSupport.firePropertyChange(DELETE_TRANSITION_CHANGE_MESSAGE, transition, null);


### PR DESCRIPTION
For changing PetriNets (used in xschemas when expanding a transition): removing a transition didn't work. Problem was that inbound arcs were not removed and crashed the executable PetriNet.