### PR TITLE
Added Test Arcs to the Petri Nets.

### DIFF
--- a/src/main/java/uk/ac/imperial/pipe/animation/PetriNetAnimationLogic.java
+++ b/src/main/java/uk/ac/imperial/pipe/animation/PetriNetAnimationLogic.java
@@ -194,6 +194,7 @@ public final class PetriNetAnimationLogic implements AnimationLogic {
     	//startState.registerEnabledTimedTransitions(enabledTransitions);
     	// TODO: successor has to be adapted.
         //Collection<Transition> enabled = getEnabledTransitions(startState);
+    	
         Collection<Transition> enabled = getEnabledImmediateOrTimedTransitions(timedState);
         logger.debug("Get Succ: " + timedState);
         if (enabled.size() > 0) {

--- a/src/main/java/uk/ac/imperial/pipe/dsl/ATestArc.java
+++ b/src/main/java/uk/ac/imperial/pipe/dsl/ATestArc.java
@@ -1,0 +1,74 @@
+package uk.ac.imperial.pipe.dsl;
+
+import uk.ac.imperial.pipe.models.petrinet.Connectable;
+import uk.ac.imperial.pipe.models.petrinet.Arc;
+import uk.ac.imperial.pipe.models.petrinet.InboundTestArc;
+import uk.ac.imperial.pipe.models.petrinet.Place;
+import uk.ac.imperial.pipe.models.petrinet.FunctionalRateParameter;
+import uk.ac.imperial.pipe.models.petrinet.Token;
+import uk.ac.imperial.pipe.models.petrinet.Transition;
+
+import java.util.Map;
+
+/**
+ * DSL for creating arcs, to be used in conjunction with {@link uk.ac.imperial.pipe.dsl.APetriNet}
+ *
+ * The format can be ATestArc.withSource("P0").andTarget("T0")
+ *
+ * For implementation reasons arcs must be declared after places and transitions
+ *
+ */
+public final class ATestArc implements DSLCreator<Arc<? extends Connectable, ? extends Connectable>> {
+    /**
+     * Test arc source
+     */
+    private String source;
+
+    /**
+     * Test arc target
+     */
+    private String target;
+
+    /**
+     * Private constructor
+     */
+    private ATestArc() {
+    }
+
+    /**
+     * Factory constructor
+     * @param source arc source
+     * @return builder
+     */
+    public static ATestArc withSource(String source) {
+        ATestArc aTestArc = new ATestArc();
+        aTestArc.source = source;
+        return aTestArc;
+    }
+
+    /**
+     * Required target for an arc
+     *
+     * @param target
+     * @return builder
+     */
+    public ATestArc andTarget(String target) {
+        this.target = target;
+        return this;
+    }
+
+
+    /**
+     * @param tokens map of created tokens with id -> Token
+     * @param places map of created places with id -> Connectable
+     * @param transitions
+     * @param rateParameters
+     * @return inhibitor arc
+     */
+    @Override
+    public Arc<? extends Connectable, ? extends Connectable> create(Map<String, Token> tokens,
+                                                                    Map<String, Place> places,
+                                                                    Map<String, Transition> transitions, Map<String, FunctionalRateParameter> rateParameters) {
+        return new InboundTestArc(places.get(source), transitions.get(target));
+    }
+}

--- a/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/ArcAdapter.java
+++ b/src/main/java/uk/ac/imperial/pipe/io/adapters/modelAdapter/ArcAdapter.java
@@ -54,10 +54,15 @@ public class ArcAdapter extends XmlAdapter<AdaptedArc, Arc<? extends Connectable
         String source = adaptedArc.getSource();
         String target = adaptedArc.getTarget();
         Map<String, String> weights = stringToWeights(adaptedArc.getInscription().getTokenCounts());
+        
         if (adaptedArc.getType().equals("inhibitor")) {
             Place place = places.get(source);
             Transition transition = transitions.get(target);
             arc = new InboundInhibitorArc(place, transition);
+        } else if (adaptedArc.getType().equals("test")) {
+        	Place place = places.get(source);
+            Transition transition = transitions.get(target);
+            arc = new InboundTestArc(place, transition);
         } else {
             if (places.containsKey(source)) {
                 Place place = places.get(source);

--- a/src/main/java/uk/ac/imperial/pipe/models/petrinet/ArcType.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/petrinet/ArcType.java
@@ -1,6 +1,6 @@
 package uk.ac.imperial.pipe.models.petrinet;
 
 public enum ArcType {
-    INHIBITOR, NORMAL
+    INHIBITOR, NORMAL, TEST
 
 }

--- a/src/main/java/uk/ac/imperial/pipe/models/petrinet/ExecutablePetriNet.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/petrinet/ExecutablePetriNet.java
@@ -340,14 +340,16 @@ public class ExecutablePetriNet extends AbstractPetriNet implements PropertyChan
 		for (Arc<Place, Transition> arc : this.inboundArcs(transition)) {
 	        Place place = arc.getSource();
 	        for (Map.Entry<String, String> entry : arc.getTokenWeights().entrySet()) {
-	            String tokenId = entry.getKey();
-	            String functionalWeight = entry.getValue();
-	            double weight = getArcWeight(functionalWeight, timedState);
-	            int currentCount = place.getTokenCount(tokenId);
-	            //int newCount = currentCount + (int) weight;
-	            // TODO: This is still strange as a place has also always a marking associated.
-	            place.setTokenCount(tokenId, subtractWeight(currentCount, (int) weight));
-	            //timedState.setState( this.getState() );
+	        	if (arc.getType() == ArcType.NORMAL) {
+	        		String tokenId = entry.getKey();
+	        		String functionalWeight = entry.getValue();
+	        		double weight = getArcWeight(functionalWeight, timedState);
+	        		int currentCount = place.getTokenCount(tokenId);
+	        		//int newCount = currentCount + (int) weight;
+	        		// TODO: This is still strange as a place has also always a marking associated.
+	        		place.setTokenCount(tokenId, subtractWeight(currentCount, (int) weight));
+	        		//timedState.setState( this.getState() );
+	        	}
 	        }
 	    }
 	}

--- a/src/main/java/uk/ac/imperial/pipe/models/petrinet/InboundTestArc.java
+++ b/src/main/java/uk/ac/imperial/pipe/models/petrinet/InboundTestArc.java
@@ -1,0 +1,39 @@
+package uk.ac.imperial.pipe.models.petrinet;
+
+import uk.ac.imperial.state.State;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A test arc maps from places to tokens and is allowed to fire
+ * if and only if its source place has any tokens whatsoever.
+ */
+public class InboundTestArc extends InboundArc {
+    /**
+     * Constructor
+     * @param source
+     * @param target
+     */
+    public InboundTestArc(Place source, Transition target) {
+        super(source, target, new HashMap<String, String>(), ArcType.TEST);
+    }
+
+    /**
+     * Analyses the state to see if the arcs source has any tokens
+     *
+     * @param petriNet
+     * @param state
+     * @return true if the arc can fire
+     */
+	@Override
+	public boolean canFire(ExecutablePetriNet executablePetriNet, State state) {
+		Map<String, Integer> tokens = state.getTokens(getSource().getId());
+		for (Integer tokenCount : tokens.values()) {
+			if (tokenCount == 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/main/java/uk/ac/imperial/pipe/petrinet/unfold/Expander.java
+++ b/src/main/java/uk/ac/imperial/pipe/petrinet/unfold/Expander.java
@@ -294,6 +294,9 @@ public final class Expander {
             case INHIBITOR:
                 newArc = new InboundInhibitorArc(source, target);
                 break;
+            case TEST:
+                newArc = new InboundTestArc(source, target);
+                break;
             default:
                 newArc = new InboundNormalArc(source, target, getNewArcWeight(arcWeight));
         }

--- a/src/main/java/uk/ac/imperial/pipe/visitor/ClonePetriNet.java
+++ b/src/main/java/uk/ac/imperial/pipe/visitor/ClonePetriNet.java
@@ -19,6 +19,7 @@ import uk.ac.imperial.pipe.models.petrinet.ExecutablePetriNet;
 import uk.ac.imperial.pipe.models.petrinet.FunctionalRateParameter;
 import uk.ac.imperial.pipe.models.petrinet.InboundArc;
 import uk.ac.imperial.pipe.models.petrinet.InboundInhibitorArc;
+import uk.ac.imperial.pipe.models.petrinet.InboundTestArc;
 import uk.ac.imperial.pipe.models.petrinet.InboundNormalArc;
 import uk.ac.imperial.pipe.models.petrinet.IncludeHierarchy;
 import uk.ac.imperial.pipe.models.petrinet.IncludeIterator;
@@ -379,6 +380,9 @@ public final class ClonePetriNet {
         switch (arc.getType()) {
             case INHIBITOR:
                 newArc = new InboundInhibitorArc(source, target);
+                break;
+            case TEST:
+                newArc = new InboundTestArc(source, target);
                 break;
             default:
                 newArc = new InboundNormalArc(source, target, arc.getTokenWeights());

--- a/src/main/java/uk/ac/imperial/pipe/visitor/PasteVisitor.java
+++ b/src/main/java/uk/ac/imperial/pipe/visitor/PasteVisitor.java
@@ -195,6 +195,9 @@ public final class PasteVisitor implements TransitionVisitor, ArcVisitor, Discre
             case INHIBITOR:
                 newArc = new InboundInhibitorArc(source, target);
                 break;
+            case TEST:
+                newArc = new InboundTestArc(source, target);
+                break;
             default:
                 newArc = new InboundNormalArc(source, target, inboundArc.getTokenWeights());
         }


### PR DESCRIPTION
I added test arcs to the Petri networks - are working in the same way as the inhibitory arcs: test arcs are inbound arcs which check if the source place is marked, and only when it is marked the target transition can be fired (depending on the other incoming arcs of course). But when the transition is fired, no tokens are removed from the source of the test arc. 
Maybe test arcs (and inhibitory arcs as well) should be weighted?

